### PR TITLE
feat. NoContext 파일 style 수정

### DIFF
--- a/src/components/NoContent/NoContent.jsx
+++ b/src/components/NoContent/NoContent.jsx
@@ -5,11 +5,13 @@ const NoContent = ({ content }) => {
   console.log(content);
   return (
     <s.NoContentLayout>
-      <s.NoImg
-        src={no_content}
-        alt="앗, 새로운 알림이 없어요!"
-      />
-      <s.NoText>앗, {content}이 없어요!</s.NoText>
+      <>
+        <s.NoImg
+          src={no_content}
+          alt="앗, 새로운 알림이 없어요!"
+        />
+        <s.NoText>앗, {content}이 없어요!</s.NoText>
+      </>
     </s.NoContentLayout>
   );
 };

--- a/src/components/NoContent/NoContentStyled.jsx
+++ b/src/components/NoContent/NoContentStyled.jsx
@@ -5,6 +5,8 @@ export const NoContentLayout = styled.div`
   flex-direction: column;
   height: 100%;
   justify-content: center;
+  position: fixed;
+  z-index: 3;
 `;
 
 export const NoImg = styled.img`
@@ -13,12 +15,12 @@ export const NoImg = styled.img`
   }
 `;
 export const NoText = styled.p`
-  color: #b8b8b8;
+  margin: 31px 0 61px;
+  color: #7a7a7a;
   text-align: center;
   font-family: Inter;
-  font-size: 14px;
+  font-size: 17px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 700;
   line-height: normal;
-  margin-top: 10px;
 `;


### PR DESCRIPTION
피그마 리팩토링 수정사항에 맞춰 데이터 없을 때 나타나는 NoContext  컴포넌트 수정
- 가운데로 오도록 상단바 만큼 margin bottom 설정
- 글씨 크기, 색상 변경
- z-index 3으로 놓음
![image](https://github.com/user-attachments/assets/63bbd0fb-525e-4054-8e4b-607143a10b63)
