### PR TITLE
에러페이지, 콘솔 삭제, 게시판 이미지 기능 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,6 +62,7 @@ import { getData, Interceptor } from './api/Functions.jsx';
 import { GET_USER_INFO } from './api/urls.jsx';
 //import axios from 'axios';
 import ChangePassword from './pages/FindPage/ChangePassword.jsx';
+import ImageSlide from './pages/Community/ImageSlide.jsx';
 
 function App() {
   const dispatch = useDispatch();
@@ -199,6 +200,10 @@ function App() {
             element={<FreeDetailPage />}
           />
           <Route
+            path="/community/general/detail/:id/images"
+            element={<ImageSlide />}
+          />
+          <Route
             path="/community/general/post"
             element={<FreePostPage />}
           />
@@ -209,6 +214,10 @@ function App() {
           <Route
             path="/community/info/detail/:id"
             element={<InfoDetailPage />}
+          />
+          <Route
+            path="/community/info/detail/:id/images"
+            element={<ImageSlide />}
           />
           <Route
             path="/community/info/post"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,24 +100,25 @@ function App() {
             //console.log('엑세스 있음');
             const res = await getData(GET_USER_INFO, {
               Authorization: `Bearer ${accessToken}`,
-            });
-            if (res) {
-              //console.log(res, 'dkdk');
-              dispatch(loadUser(res.data, accessToken));
-              if (res.data.userStatus == 'TEMPORARY') {
-                //사용자가 임의로 주소 수정해서 들어오면 이쪽으로 안내..
-                //임의로 수정=새로 마운트 되므로 리덕스 유저인포는 없어서 이 로직이 맞음
-                nav('/signUp/credentials');
-              }
+            })
+              .then((res) => {
+                //console.log(res, 'dkdk');
+                dispatch(loadUser(res.data, accessToken));
+                if (res.data.userStatus == 'TEMPORARY') {
+                  //사용자가 임의로 주소 수정해서 들어오면 이쪽으로 안내..
+                  //임의로 수정=새로 마운트 되므로 리덕스 유저인포는 없어서 이 로직이 맞음
+                  nav('/signUp/credentials');
+                }
 
-              //console.log('앱 유저인포:', userInfo);
-              setIsLoading(false);
-            }
-          } else {
-            dispatch(logout());
-            alert('로그인이 필요합니다.');
-            nav('/signIn');
-            requestNotificationPermissionOnce();
+                //console.log('앱 유저인포:', userInfo);
+                setIsLoading(false);
+              })
+              .catch(() => {
+                dispatch(logout());
+                alert('로그인이 필요합니다.');
+                nav('/signIn');
+                requestNotificationPermissionOnce();
+              });
           }
         };
         try {

--- a/src/api/Functions.jsx
+++ b/src/api/Functions.jsx
@@ -50,10 +50,7 @@ export const Interceptor = ({ children }) => {
           let prevRequest = error.config;
           //console.log(error.response.status);
 
-          if (
-            (!isSignedOut && error.response.status == Number(403)) ||
-            error.response.status == Number(401)
-          ) {
+          if (true) {
             //console.log('그러나 인증 토큰이 없거나 유효하지 않은 경우');
             const aToken = localStorage.getItem('AToken')
               ? localStorage.getItem('AToken')
@@ -130,6 +127,7 @@ export const Interceptor = ({ children }) => {
       }
     },
   );
+
   return children;
 };
 

--- a/src/api/Functions.jsx
+++ b/src/api/Functions.jsx
@@ -19,17 +19,19 @@ const apiClient = axios.create({
 export const Interceptor = ({ children }) => {
   const dispatch = useDispatch();
   const nav = useNavigate();
-  let userInfo = useSelector((state) => state.user.user);
+  //let userInfo = useSelector((state) => state.user.user);
 
-  apiClient.interceptors.request.use((config) => {
-    //console.log('이거');
-    //console.log(config);
-    if (config.headers['Authorization']) {
-      //console.log('인증이 필요한 경우');
-      //console.log(config);
-    }
-    return config;
-  });
+  // apiClient.interceptors.request.use((config) => {
+  //   //console.log('이거');
+  //   console.log(config);
+  //   if (config?.headers['Authorization']) {
+  //     //console.log('인증이 필요한 경우');
+  //     //console.log(config);
+  //     config.headers['Authorization'] =
+  //       `Bearer ${localStorage.getItem('AToken')}`;
+  //   }
+  //   return config;
+  // });
 
   apiClient.interceptors.response.use(
     (res) => {
@@ -44,7 +46,7 @@ export const Interceptor = ({ children }) => {
       //console.log(error);
       //console.log('인터셉터 에러 내부');
       if (!isSignedOut) {
-        //console.log(error);
+        console.log(error);
         if (error.config.headers['Authorization']) {
           //console.log('인증 토큰이 필요한 경우');
           let prevRequest = error.config;
@@ -160,7 +162,7 @@ export const getData = async (url, headers = {}, params = {}) => {
   const response = await apiClient
     .get(url, { headers: { ...headers }, params: { ...params } })
     .then((response) => {
-      //console.log(response);
+      console.log(response);
       return response;
     })
     .catch((error) => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,11 +14,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <Provider store={store}>
     <BrowserRouter>
       <Interceptor>
-        <React.StrictMode>
-          <QueryClientProvider client={queryClient}>
-            <App />
-          </QueryClientProvider>
-        </React.StrictMode>
+        {/* <React.StrictMode> */}
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+        {/* </React.StrictMode> */}
       </Interceptor>
     </BrowserRouter>
   </Provider>,

--- a/src/pages/Community/CommunityHome.jsx
+++ b/src/pages/Community/CommunityHome.jsx
@@ -19,6 +19,7 @@ import { getData } from '../../api/Functions.jsx';
 import { GET_FILTERED_POST_IN, GET_POST_OF } from '../../api/urls.jsx';
 import { throttle } from 'rxjs';
 import { loadUser, logout } from '../../redux/actions.jsx';
+import ErrorScreen from '../../components/ErrorScreen.jsx';
 
 const images = [communityBannerImg, communityBannerImg, communityBannerImg];
 
@@ -29,6 +30,7 @@ const CommunityHome = ({ boardType, color1, color2 }) => {
   const [showCountry, setShowCountry] = useState(false); //모달창
   const [country, setCountry] = useState(null); //선택된 국가
   const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [postList, setPostList] = useState(null);
   const totalPage = useRef(0);
   const currentPage = useRef(0);
@@ -67,18 +69,22 @@ const CommunityHome = ({ boardType, color1, color2 }) => {
         Authorization: `${localStorage.getItem('grantType')} ${localStorage.getItem('AToken')}`,
       },
       { page: currentPage.current, size: 5, sort: 'DESC' },
-    );
-    if (response) {
-      totalPage.current = response.data.totalPages;
-      if (currentPage.current > 0) {
-        setPostList((postList) => [...postList, ...response.data.content]);
-        //console.log('내용 존재');
-      } else {
-        setPostList(response.data.content);
-        //console.log('이거 실행');
-      }
-    }
-    return response;
+    )
+      .then((response) => {
+        totalPage.current = response.data.totalPages;
+        if (currentPage.current > 0) {
+          setPostList((postList) => [...postList, ...response.data.content]);
+          //console.log('내용 존재');
+        } else {
+          setPostList(response.data.content);
+          //console.log('이거 실행');
+        }
+        setIsError(false);
+        return response;
+      })
+      .catch((error) => {
+        setIsError(true);
+      });
   };
   const fetchFilteredData = async () => {
     if (currentPage.current == 0) {
@@ -129,15 +135,12 @@ const CommunityHome = ({ boardType, color1, color2 }) => {
         currentPage.current < totalPage.current
       ) {
         currentPage.current++;
-        console.log(currentPage.current);
-        console.log(totalPage.current);
-        console.log(isLoading);
         if (country === null) {
           await fetchData();
         } else {
           await fetchFilteredData();
         }
-        console.log(isLoading);
+
         newDataLoading.current = false;
       }
     }
@@ -160,6 +163,9 @@ const CommunityHome = ({ boardType, color1, color2 }) => {
 
   if (isLoading) {
     return <Loading />;
+  }
+  if (isError) {
+    return <ErrorScreen />;
   }
 
   return (
@@ -195,7 +201,6 @@ const CommunityHome = ({ boardType, color1, color2 }) => {
         <s.PostListSection>
           {postList && postList.length > 0 ? (
             postList.map((post) => {
-              console.log(post);
               return (
                 <CommunityPost
                   key={post.postId}

--- a/src/pages/Community/DetailPage.jsx
+++ b/src/pages/Community/DetailPage.jsx
@@ -42,6 +42,7 @@ const DetailPage = ({ color1, color2, boardType }) => {
   const totalPage = useRef(0);
   const newCommentLoading = useRef(0);
   const myCommentId = useRef(null);
+  const nav = useNavigate();
 
   const fetchCommentData = async (order = 'DESC') => {
     if (currentPage.current === 0) {
@@ -98,8 +99,11 @@ const DetailPage = ({ color1, color2, boardType }) => {
           totalPage.current = commentResponse.data.totalPages;
           setCommentCount(commentResponse.data.totalElements);
         } catch (error) {
-          //console.error('Error fetching data:', error);
-          setIsError(true);
+          console.error('Error fetching data:', error);
+          console.log(currentPost_id);
+          if (!isLoading) {
+            setIsError(true);
+          }
         } finally {
           setLoading(false); // 성공적이든 실패든 최종적으로 로딩을 끝내도록
         }
@@ -241,6 +245,9 @@ const DetailPage = ({ color1, color2, boardType }) => {
   if (isLoading) {
     return <Loading />;
   }
+  if (isError) {
+    return <ErrorScreen />;
+  }
   //const currentVisualViewHeight = window.visualViewport.height;
   //replyToText.current = currentVisualViewHeight;
   if (userInfo && currentPost && commentList) {
@@ -285,7 +292,13 @@ const DetailPage = ({ color1, color2, boardType }) => {
                       key={index}
                       onClick={(e) => {
                         openedImg.current = e.target.src;
-                        setImageModalOpen(true);
+                        nav('./images', {
+                          state: {
+                            list: currentPost.imageUrls,
+                            clickedImg: img,
+                            clickedIndex: index,
+                          },
+                        });
                       }}
                     />
                   ))
@@ -345,7 +358,7 @@ const DetailPage = ({ color1, color2, boardType }) => {
               }
             })}
           </s.CommentSection>
-          {isImageModalOpen && (
+          {/* {isImageModalOpen && (
             <ImgModal
               onClick={() => {
                 setImageModalOpen(false);
@@ -353,7 +366,7 @@ const DetailPage = ({ color1, color2, boardType }) => {
             >
               <Img src={openedImg.current} />
             </ImgModal>
-          )}
+          )} */}
         </s.DetailPageLayout>
         <s.CommentWritingDiv id="commentDiv">
           <div

--- a/src/pages/Community/DetailPage.jsx
+++ b/src/pages/Community/DetailPage.jsx
@@ -14,6 +14,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getData, postData } from '../../api/Functions.jsx';
+import { useSwipeable } from 'react-swipeable';
 import {
   GET_COMMENT_OF,
   GET_POST_DETAIL,
@@ -154,6 +155,12 @@ const DetailPage = ({ color1, color2, boardType }) => {
     }
   };
 
+  const handlers = useSwipeable({
+    preventScrollOnSwipe: true,
+    preventDefaultTouchmoveEvent: true,
+    trackMouse: true,
+  });
+
   useEffect(() => {
     //setLoading(true)
     let throttleCheck = false;
@@ -241,6 +248,11 @@ const DetailPage = ({ color1, color2, boardType }) => {
     fetchCommentData();
     setLoading(false);
   };
+  const isMobile = () => {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent,
+    );
+  };
 
   if (isLoading) {
     return <Loading />;
@@ -284,14 +296,14 @@ const DetailPage = ({ color1, color2, boardType }) => {
           </s.Title>
           <s.Content>
             {currentPost.content}
-            <s.ImgSection>
-              {currentPost.imageUrls
-                ? currentPost.imageUrls.map((img, index) => (
+            {currentPost.imageUrls ? (
+              <s.ImgSection isMobile={isMobile()}>
+                {currentPost.imageUrls.length > 1 ? (
+                  currentPost.imageUrls.map((img, index) => (
                     <s.ContentImg
                       src={img}
                       key={index}
-                      onClick={(e) => {
-                        openedImg.current = e.target.src;
+                      onClick={() => {
                         nav('./images', {
                           state: {
                             list: currentPost.imageUrls,
@@ -302,8 +314,22 @@ const DetailPage = ({ color1, color2, boardType }) => {
                       }}
                     />
                   ))
-                : null}
-            </s.ImgSection>
+                ) : (
+                  <OneBigImg
+                    src={currentPost.imageUrls[0]}
+                    onClick={() => {
+                      nav('./images', {
+                        state: {
+                          list: currentPost.imageUrls,
+                          clickedImg: img,
+                          clickedIndex: index,
+                        },
+                      });
+                    }}
+                  />
+                )}
+              </s.ImgSection>
+            ) : null}
           </s.Content>
           <s.CommentNumSection>
             <img
@@ -358,15 +384,6 @@ const DetailPage = ({ color1, color2, boardType }) => {
               }
             })}
           </s.CommentSection>
-          {/* {isImageModalOpen && (
-            <ImgModal
-              onClick={() => {
-                setImageModalOpen(false);
-              }}
-            >
-              <Img src={openedImg.current} />
-            </ImgModal>
-          )} */}
         </s.DetailPageLayout>
         <s.CommentWritingDiv id="commentDiv">
           <div
@@ -452,9 +469,11 @@ const ImgModal = styled.div`
   background: black;
   z-index: 3;
 `;
-const Img = styled.div`
+const OneBigImg = styled.img`
+  position: relative;
   width: 100%;
-  height: 100%;
-  background: ${(props) => `url(${props.src})`} no-repeat center;
-  background-size: contain;
+  align-self: center;
+  justify-self: center;
+  //background: ${(props) => `url(${props.src})`} no-repeat center;
+  object-fit: cover;
 `;

--- a/src/pages/Community/DetailPage.jsx
+++ b/src/pages/Community/DetailPage.jsx
@@ -300,7 +300,6 @@ const DetailPage = ({ color1, color2, boardType }) => {
                         nav('./images', {
                           state: {
                             list: currentPost.imageUrls,
-                            clickedImg: img,
                             clickedIndex: index,
                           },
                         });
@@ -314,8 +313,7 @@ const DetailPage = ({ color1, color2, boardType }) => {
                       nav('./images', {
                         state: {
                           list: currentPost.imageUrls,
-                          clickedImg: img,
-                          clickedIndex: index,
+                          clickedIndex: 0,
                         },
                       });
                     }}

--- a/src/pages/Community/DetailPage.jsx
+++ b/src/pages/Community/DetailPage.jsx
@@ -21,7 +21,7 @@ import {
   WRITE_REPLY_ON,
 } from '../../api/urls.jsx';
 import Loading from '../../components/Loading/Loading.jsx';
-
+import ErrorScreen from '../../components/ErrorScreen.jsx';
 import Reply from '../../components/Comment/Reply.jsx';
 
 const DetailPage = ({ color1, color2, boardType }) => {
@@ -35,6 +35,7 @@ const DetailPage = ({ color1, color2, boardType }) => {
   const [currentPost, setCurrentPost] = useState();
   const [commentList, setCommentList] = useState(null);
   const [isLoading, setLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [isImageModalOpen, setImageModalOpen] = useState(false);
   const openedImg = useRef(null);
   const currentPage = useRef(0);
@@ -98,6 +99,7 @@ const DetailPage = ({ color1, color2, boardType }) => {
           setCommentCount(commentResponse.data.totalElements);
         } catch (error) {
           //console.error('Error fetching data:', error);
+          setIsError(true);
         } finally {
           setLoading(false); // 성공적이든 실패든 최종적으로 로딩을 끝내도록
         }

--- a/src/pages/Community/DetailPage.jsx
+++ b/src/pages/Community/DetailPage.jsx
@@ -135,13 +135,6 @@ const DetailPage = ({ color1, color2, boardType }) => {
       window.scrollY + document.documentElement.clientHeight >
       document.documentElement.scrollHeight - 50
     ) {
-      //console.log('api 호출');
-      // console.log(
-      //   isLoading,
-      //   newCommentLoading.current,
-      //   currentPage.current,
-      //   totalPage.current,
-      // );
       if (
         !isLoading &&
         !newCommentLoading.current &&

--- a/src/pages/Community/DetailPageStyled.jsx
+++ b/src/pages/Community/DetailPageStyled.jsx
@@ -1,3 +1,4 @@
+import { css } from 'styled-components';
 import styled from 'styled-components';
 
 export const PostInfoHeader = styled.div`
@@ -396,21 +397,28 @@ export const ImgSection = styled.section`
   justify-content: start;
   flex-wrap: nowrap;
   gap: 1rem;
-  padding-top: 1rem;
+  padding: 1rem 0;
   overflow-x: scroll;
-  &:hover::-webkit-scrollbar {
-    display: inside;
-    height: 0.5rem;
-  }
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  &::-webkit-scrollbar-thumb {
-    width: 0.5rem;
-    background: gray; /* 스크롤바 막대 색상 */
-    /* 스크롤바 막대 테두리 설정  */
-    border-radius: 12px;
-  }
+  ${(props) =>
+    props.isMobile
+      ? css`
+          &::-webkit-scrollbar {
+            display: none;
+          }
+        `
+      : css`
+          &::-webkit-scrollbar {
+            display: inside;
+            height: 0.5rem;
+            display: 2px solid;
+          }
+          &::-webkit-scrollbar-thumb {
+            width: 0.5rem;
+            background: gray; /* 스크롤바 막대 색상 */
+            /* 스크롤바 막대 테두리 설정  */
+            border-radius: 12px;
+          }
+        `}
 `;
 
 export const ContentImg = styled.img`

--- a/src/pages/Community/ImageSlide.jsx
+++ b/src/pages/Community/ImageSlide.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import { useSwipeable } from 'react-swipeable';
+const ImageSlide = () => {
+  const { list, clickedImg, clickedIndex } = useLocation().state;
+  const [currentImgIndex, setCurrentImageIndex] = useState(clickedIndex);
+  //const [stopScroll, setStopScroll] = useState(false);
+
+  console.log(list.length);
+  console.log(currentImgIndex);
+  const nextImage = () => {
+    setCurrentImageIndex((prevIndex) => {
+      if (prevIndex < list.length - 1) {
+        return prevIndex + 1;
+      } else {
+        return prevIndex;
+      }
+    });
+  };
+  const prevImage = () => {
+    setCurrentImageIndex((prevIndex) => {
+      if (prevIndex > 0) {
+        return prevIndex - 1;
+      } else {
+        return prevIndex;
+      }
+    });
+  };
+  const handlers = useSwipeable({
+    onSwipedLeft: nextImage,
+    onSwipedRight: prevImage,
+    preventScrollOnSwipe: true,
+    preventDefaultTouchmoveEvent: true,
+    trackMouse: true,
+  });
+  return (
+    <>
+      <ImgModal {...handlers}>
+        <SliderWrapper currentSlide={currentImgIndex}>
+          {list.map((img, index) => (
+            <Img
+              src={img}
+              key={index}
+            />
+          ))}
+        </SliderWrapper>
+      </ImgModal>
+    </>
+  );
+};
+
+export default ImageSlide;
+
+const ImgModal = styled.div`
+  width: 100vw;
+  max-width: 480px;
+  height: 100vh;
+  margin: 0 auto;
+  overflow: hidden;
+  background-color: black;
+`;
+const SliderWrapper = styled.div.withConfig({
+  shouldForwardProp: (prop) => !['currentSlide'].includes(prop),
+})`
+  display: flex;
+  transition: transform 0.3s ease-in-out;
+  transform: ${(props) => `translateX(-${props.currentSlide * 100}%)`};
+  position: relative; /* Added to contain absolutely positioned elements */
+  height: 100%; /* Ensure it takes full height of the container */
+`;
+const Img = styled.div`
+  min-width: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-use-select: none;
+  user-select: none;
+  background: ${(props) => `url(${props.src})`} no-repeat center;
+  background-size: contain;
+`;

--- a/src/pages/Community/ImageSlide.jsx
+++ b/src/pages/Community/ImageSlide.jsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { useSwipeable } from 'react-swipeable';
 const ImageSlide = () => {
-  const { list, clickedImg, clickedIndex } = useLocation().state;
+  const { list, clickedIndex } = useLocation().state;
   const [currentImgIndex, setCurrentImageIndex] = useState(clickedIndex);
   //const [stopScroll, setStopScroll] = useState(false);
+  const nav = useNavigate();
 
   const nextImage = () => {
     setCurrentImageIndex((prevIndex) => {
@@ -28,6 +29,7 @@ const ImageSlide = () => {
   const handlers = useSwipeable({
     onSwipedLeft: nextImage,
     onSwipedRight: prevImage,
+
     preventScrollOnSwipe: true,
     preventDefaultTouchmoveEvent: true,
     trackMouse: true,

--- a/src/pages/Community/ImageSlide.jsx
+++ b/src/pages/Community/ImageSlide.jsx
@@ -7,8 +7,6 @@ const ImageSlide = () => {
   const [currentImgIndex, setCurrentImageIndex] = useState(clickedIndex);
   //const [stopScroll, setStopScroll] = useState(false);
 
-  console.log(list.length);
-  console.log(currentImgIndex);
   const nextImage = () => {
     setCurrentImageIndex((prevIndex) => {
       if (prevIndex < list.length - 1) {

--- a/src/pages/Community/PostPage.jsx
+++ b/src/pages/Community/PostPage.jsx
@@ -9,11 +9,13 @@ import { multiFilePostData } from '../../api/Functions.jsx';
 import { showDispatchedInfo } from '../../components/Common/InfoExp.jsx';
 import { WRITE_POST_IN } from '../../api/urls.jsx';
 import ImageSection from './ImageSection.jsx';
+import ErrorScreen from '../../components/ErrorScreen.jsx';
 
 const PostPage = ({ color, boardType }) => {
   const navigate = useNavigate();
   const [imageFiles, setImageFiles] = useState([]);
   const [isLoading, setLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
 
   let userInfo = useSelector((state) => state.user.user);
 
@@ -50,6 +52,9 @@ const PostPage = ({ color, boardType }) => {
 
   if (isLoading) {
     return <Loading />;
+  }
+  if (isError) {
+    return <ErrorScreen />;
   }
   if (BETest && !userInfo) {
     return null;
@@ -103,17 +108,18 @@ const PostPage = ({ color, boardType }) => {
         {
           Authorization: `${localStorage.getItem('grantType')} ${localStorage.getItem('AToken')}`,
         },
-      );
-      if (response) {
-        //console.log(response.data.result);
-        return response;
-      }
+      )
+        .then((res) => res)
+        .catch((error) => {
+          setIsError(true);
+        });
+      return response;
     };
     const sendingComplete = await sendData();
     if (sendingComplete) {
       setLoading(false);
 
-      navigate(`/community/${boardType == 'FREE' ? 'general' : 'info'}`, {
+      navigate(-1, {
         replace: true,
       });
     }

--- a/src/pages/SignUp/SignInPage.jsx
+++ b/src/pages/SignUp/SignInPage.jsx
@@ -2,7 +2,7 @@ import * as s from './SignUpStyled';
 import styled from 'styled-components';
 import groupLogo from '../../assets/images/NewLogo.svg';
 import { useNavigate } from 'react-router-dom';
-import { loginSuccess, loginFailure } from '../../redux/actions';
+import { loginSuccess, loginFailure, logout } from '../../redux/actions';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useRef, useState } from 'react';
 
@@ -18,6 +18,9 @@ const SignInPage = () => {
   let userInfo = useSelector((state) => {
     state.user.user;
   });
+  useEffect(() => {
+    dispatch(logout());
+  }, []);
   useEffect(() => {
     //유저 상태에 따른 조건부 네비게이팅
     if (userInfo) {

--- a/src/pages/SignUp/SignInPage.jsx
+++ b/src/pages/SignUp/SignInPage.jsx
@@ -88,6 +88,7 @@ const SignInPage = () => {
           alert('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
         }
       } else {
+        console.log(error);
         alert('네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.');
       }
       dispatch(loginFailure('Invalid email or password'));


### PR DESCRIPTION
# 수정사항
담당 페이지에 에러페이지 추가
콘솔 삭제
인터셉터 로직 수정
## 게시글 이미지 관련
이미지 클릭하여 원본 보기 시 스와이핑으로 다음 사진 볼 수 있도록 함.
#### 이미지가 원래 모달이었는데, 새로운 페이지로 라우팅하도록 함. 모달로 할 경우 뒤로가기 버튼 누르면 상세 게시글이 아닌 게시글 목록으로 가기 때문에.... (사용자 입장에서 상세 페이지로 돌아가는게 더 직관적이라 판단)
#### 접속 기기가 컴퓨터일 때는 이미지 목록이 드래그 되지 않아 여러장 첨부 시 이미지가 다 보이지 않는데도 드래그할 수 없는 문제 발생. --> 접속 기기에 따라 컴퓨터에서는 스크롤바가 보이고, 모바일 환경에서는 드래그 가능하므로 스크롤바 보이지 않게 변경