### PR TITLE
style: 홈 화면 파견교 텍스트 잘리는 문제 해결

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -284,7 +284,7 @@ function HomePage() {
           setAccompanyData([]);
         }
       } catch (error) {
-        return <ErrorScreen/>
+        return <ErrorScreen />;
         // console.error('Error fetching data:', error);
       } finally {
         setIsLoading(false); // Data fetched, stop showing main loading
@@ -311,7 +311,7 @@ function HomePage() {
           setAccompanyData([]);
         }
       } catch (error) {
-        return <ErrorScreen/>
+        return <ErrorScreen />;
         // console.error('Error fetching data:', error);
         setAccompanyData([]);
       } finally {
@@ -604,6 +604,7 @@ const BigContainer = styled.div`
 const LeftContainer = styled.div`
   display: flex;
   justify-content: flex-start;
+  align-items: center;
 `;
 
 const SubText = styled.div`
@@ -646,6 +647,7 @@ const BigText = styled.div`
   text-overflow: ellipsis;
   display: block;
   max-width: 90%;
+  line-height: 1.2;
 `;
 
 const MiddleText = styled.div`


### PR DESCRIPTION
#### before
<img width="372" alt="스크린샷 2024-12-23 오후 2 37 38" src="https://github.com/user-attachments/assets/fcc0f8d2-9abf-4099-8030-453eb08d2083" />
'g'와 'y'의 아래가 미세하게 잘리는 걸 확인할 수 있었습니다. 

#### after
<img width="286" alt="스크린샷 2024-12-23 오후 2 37 16" src="https://github.com/user-attachments/assets/fe883bc8-3d8f-44e3-b836-91ce67df598e" />
