### PR TITLE
style, chore: 일기 페이지 디테일 스타일 수정, manifest.json 파일 경로 수정 1건

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -47,7 +47,7 @@
       "density": "4.0"
     },
     {
-      "src": "/public/icon/web-app-manifest-512x512.png",
+      "src": "/icon/web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/src/components/DailyDiary.jsx
+++ b/src/components/DailyDiary.jsx
@@ -9,7 +9,7 @@ const StoredDiary = ({ diaries }) => {
         <DailyDiary key={index}>
           <Content>{item.content}</Content>
           <Date>{item.diaryDate}</Date>
-          <DDay>{`D${item.writtenDday === 0 ? "-Day" : item.writtenDday < 0 ? ` + ${Math.abs(item.writtenDday)}` : ` - ${item.writtenDday}`}`}</DDay>
+          <DDay>{`D${item.writtenDday === 0 ? "-Day" : item.writtenDday < 0 ? `+${Math.abs(item.writtenDday)}` : `-${item.writtenDday}`}`}</DDay>
         </DailyDiary>
       ))}
     </>
@@ -34,10 +34,10 @@ const DailyDiary = styled.div`
 `;
 
 const DDay = styled.div`
-  width: 42px;
+  width: 45px;
   height: 18px;
   border-radius: 9px;
-  background: ${props => props.theme.blueGra};
+  background: ${props => props.theme.purpleGra};
   color: white;
   font-size: 0.75rem;
   display: flex;
@@ -56,7 +56,7 @@ const Content = styled.p`
 `;
 
 const Date = styled.p`
-  font-size: 11px;
+  font-size: 12px;
   margin: 10px;
   margin-left: 0px;
   font-weight: 600;

--- a/src/pages/Diary/DiaryPage.jsx
+++ b/src/pages/Diary/DiaryPage.jsx
@@ -330,7 +330,7 @@ const NewDiary = styled.textarea`
   padding: 20px;
   &::placeholder {
     color: #838383;
-    font-size: 13px;
+    font-size: 0.95rem;
     font-family: 'Inter';
   }
   outline: none;
@@ -341,7 +341,7 @@ const Save = styled.div`
   width: 40px;
   height: 22px;
   border-radius: 13px;
-  background: ${(props) => props.theme.blueGra};
+  background: ${(props) => props.theme.purpleGra};
   color: white;
   font-size: 0.85rem;
   display: flex;


### PR DESCRIPTION
일기 페이지에서 
1. placeholder의 폰트와 일기 데이터 폰트의 크기가 맞지 않는 것 수정
2. 수정 버튼이 bluegra에서는 잘 보이지 않는 것 같아, purplegra로 변경하였습니다. 
3. 그 외 폰트 크기 등 디테일한 스타일만 수정

<img width="304" alt="스크린샷 2024-12-23 오후 7 55 32" src="https://github.com/user-attachments/assets/88ab872a-3396-4ce8-b5d6-b0f509c94a59" />
before

+) manefiest.json에 경로가 잘못된 이미지 -> 경로에서 'Public' 제거