### PR TITLE
fix: ios 빌드 후 시뮬레이터에서 스크롤 안 되는 문제 fix 시도

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,19 @@
   font-family: 'Inter';
 }
 
+html,
+body {
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch; /* iOS에서 스크롤 부드럽게 */
+}
+
+.container {
+  height: 100%;
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
+}
+
 .logo {
   height: 6em;
   padding: 1.5em;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,10 @@
 import { defineConfig } from 'vite';
-//import vercel from 'vite-plugin-vercel';
+import vercel from 'vite-plugin-vercel';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()],
   server: {
-    host: 'localhost',
-    port: 3000,
+    port: 443,
   },
-  //plugins: [react(), vercel()],
+  plugins: [react(), vercel()],
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vite';
-import vercel from 'vite-plugin-vercel';
+//import vercel from 'vite-plugin-vercel';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   server: {
-    port: 443,
+    //port: 443,
+    port: 3000,
+    host: 'localhost',
   },
-  plugins: [react(), vercel()],
+  //plugins: [react(), vercel()],
+  plugins: [react()],
 });


### PR DESCRIPTION
css 파일에 ios 스크롤 관련 코드 추가
main으로 병합 후 다시 pwabuilder 패키징 후에 ios로 빌드 후에 test 해보아야 함! 

## 바로 ios 빌드 테스트 해보려고 해서 확인하시면 **_바로 머지_**해주시면 감사하겠습니다!!


아래 사진들은 아주 약소한 선물임니다.. ㅎㅎ(Iphone16 프로 시뮬레이터로 돌려본 스크롤 안 되는 ios 화면입니다)

![Simulator Screenshot - iPhone 16 Pro - 2025-01-02 at 22 43 55](https://github.com/user-attachments/assets/28b8d68d-0617-431c-b083-82d328c89e98)
![Simulator Screenshot - iPhone 16 Pro - 2025-01-02 at 22 38 33](https://github.com/user-attachments/assets/4534f778-4134-4014-b3a4-af11024f7dd5)
![Simulator Screenshot - iPhone 16 Pro - 2025-01-02 at 22 37 50](https://github.com/user-attachments/assets/2ab983c1-9cd0-4ce2-a843-9fe6cfc32896)
![Simulator Screenshot - iPhone 16 Pro - 2025-01-02 at 22 44 06](https://github.com/user-attachments/assets/a5b0c629-d2d4-42fd-8c98-defe57311eae)
![Simulator Screenshot - iPhone 16 Pro - 2025-01-02 at 22 44 54](https://github.com/user-attachments/assets/e310de4c-166a-4a9a-b7f6-d739af821868)

